### PR TITLE
chore: fixing the download script to run as GH Action

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -146,7 +146,7 @@
       "name": "update-sources:config-xsd",
       "steps": [
         {
-          "exec": "curl -s https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html | grep -Ewo 'amazon-mq-active-mq-\\d+\\.\\d+\\.\\d+\\.xsd\\.zip' | awk '{ print \"https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/samples/\" $0 \" \" $0 }' | xargs -L1 bash -c 'curl $0 --output $1 && unzip -o $1 && rm $1'"
+          "exec": "curl -s https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html | grep -Ewo 'amazon-mq-active-mq-[0-9]+\\.[0-9]+\\.[0-9]+\\.xsd\\.zip' | awk '{ print \"https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/samples/\" $0 \" \" $0 }' | xargs -L1 bash -c 'curl $0 --output $1 && unzip -o $1 && rm $1'"
         }
       ],
       "cwd": "sources"

--- a/projenrc/download-script.ts
+++ b/projenrc/download-script.ts
@@ -4,7 +4,7 @@ import { TaskOptions, TaskStep } from 'projen';
 // xsdUrlPrefix: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/samples/
 export class DownloadScript implements TaskOptions, TaskStep {
     public get exec(): string {
-        return `curl -s ${this.url} | grep -Ewo 'amazon-mq-active-mq-\\d+\\.\\d+\\.\\d+\\.xsd\\.zip' | awk '{ print \"${this.xsdUrlPrefix}\" $0 \" \" $0 }' | xargs -L1 bash -c 'curl $0 --output $1 && unzip -o $1 && rm $1'`.trimEnd();
+        return `curl -s ${this.url} | grep -Ewo 'amazon-mq-active-mq-[0-9]+\\.[0-9]+\\.[0-9]+\\.xsd\\.zip' | awk '{ print \"${this.xsdUrlPrefix}\" $0 \" \" $0 }' | xargs -L1 bash -c 'curl $0 --output $1 && unzip -o $1 && rm $1'`.trimEnd();
     }
 
     public constructor(private readonly url: string, private readonly xsdUrlPrefix: string) { }


### PR DESCRIPTION
This PR modifies the `grep` expression to run as GitHub Action. 

The `grep` command on Ubuntu OS (which underpins the GH Action) does not understand the `\d` regular expression when `-E` flag is used. That is why the change from `\d` to `[0-9]` is made. 